### PR TITLE
be more forgiving with username format

### DIFF
--- a/controllers/coinbase_controller.rb
+++ b/controllers/coinbase_controller.rb
@@ -1,20 +1,28 @@
+require 'pathname'
+
 class ::CoinbaseController < ::ApplicationController
   def tip_id
-    u = User.find_by(id: params[:id])
-    f = UserField.find_by(name: 'Coinbase Username')
+    @u = User.find_by(id: params[:id])
+    @f = UserField.find_by(name: 'Coinbase Username')
 
-    if u.user_fields["#{f.id}"].present?
-      return render json: { cb_id: ERB::Util.html_escape(u.user_fields["#{f.id}"]) }
+    if @u.user_fields["#{@f.id}"].present?
+      return render json: { cb_id: clean_username }
     end
 
-    s = SiteSetting.where(name: 'sso_url')
+    @s = SiteSetting.where(name: 'sso_url')
 
-    if !s.blank? && s.first.value.match(%r{^https://www.coinbase.com/})
-      unless u.single_sign_on_record.nil?
-        return render json: { cb_id: u.single_sign_on_record['external_id'] }
+    if !@s.blank? && @s.first.value.match(%r{^https://www.coinbase.com/})
+      unless @u.single_sign_on_record.nil?
+        return render json: { cb_id: @u.single_sign_on_record['external_id'] }
       end
     end
 
     render json: { cb_id: 'coinbase' }
+  end
+
+  private
+
+  def clean_username
+    Pathname.new(ERB::Util.html_escape(@u.user_fields["#{@f.id}"])).basename.to_s
   end
 end


### PR DESCRIPTION
If a user provides their "Coinbase Username" parameter as a url to their payment page ('coinbase.com/satoshi' instead of just 'satoshi'), use the name part only. This will make sure tip buttons work for people that don't follow directions :)
